### PR TITLE
dropConnection improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ params should be an object with the following keys:
 `callback(err)` will be executed on success or failure.  err is either an error object, or undefined on successful connection.
 
 
-#### <a name="drop-connection"></a>nodes7.dropConnection()
+#### <a name="drop-connection"></a>nodes7.dropConnection(callback)
 Disconnects from a PLC.  
 
-This simply terminates the TCP connection.
+This simply terminates the TCP connection. The callback is called upon completion of the close.
 
 
 #### <a name="set-translation-cb"></a>nodes7.setTranslationCB(translator)

--- a/nodeS7.js
+++ b/nodeS7.js
@@ -128,7 +128,10 @@ NodeS7.prototype.dropConnection = function (callback) {
       self.dropConnectionCallback = callback;
       self.isoclient.end();
       // now wait for 'on close' event to trigger connection cleanup
-  }	
+  }	else {
+      // if client not active, then callback immediately
+      callback();
+  }
 }
 
 NodeS7.prototype.connectNow = function (cParam, suppressCallback) {


### PR DESCRIPTION
Hi, in my environment it is required to enable (initiateConnection) and disable (dropConnection) multiple times.

The S7 (a 1200) I was connecting to was triggering a ECONNRESET error after we sent the FIN packet (triggered by the dropConnection), and as the connection had already been cleaned up, the error was not trapped and caused the node process to terminate.

I have added a 'on close' handler that gets called once the connection has truely closed, and at this point do the connection cleanup.

Also as the closing of a connection is asynchronous, I added an asynchronous callback for the dropConnection method, so that the callee will know when the connection is all done with.  