### PR TITLE
Fix error when reading across multiple DBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version: 0.1.11
+------------
+- Fix error when reading across multiple DBs
+
 Version: 0.1.10
 ------------
 - Fix errors writing single/multiple items of bit and byte length

--- a/nodeS7.js
+++ b/nodeS7.js
@@ -757,6 +757,9 @@ NodeS7.prototype.prepareReadPacket = function() {
 			(!self.isOptimizableArea(itemList[i].areaS7Code)) || 					// Can't optimize T,C (I don't think) and definitely not P.
 			((itemList[i].offset - self.globalReadBlockList[thisBlock].offset + itemList[i].byteLength) > maxByteRequest) ||      	// If this request puts us over our max byte length, create a new block for consistency reasons.
 			(itemList[i].offset - (self.globalReadBlockList[thisBlock].offset + self.globalReadBlockList[thisBlock].byteLength) > self.maxGap)) {		// If our gap is large, create a new block.
+			
+			outputLog("Skipping optimization of item " + itemList[i].addr, 0, self.connectionID);
+			
 			// At this point we give up and create a new block.
 			thisBlock = thisBlock + 1;
 			self.globalReadBlockList[thisBlock] = itemList[i]; // By reference.
@@ -2229,6 +2232,12 @@ function itemListSorter(a, b) {
 	// Feel free to manipulate these next two lines...
 	if (a.areaS7Code < b.areaS7Code) { return -1; }
 	if (a.areaS7Code > b.areaS7Code) { return 1; }
+
+	// Group first the items of the same DB
+	if (a.addrtype === 'DB') {
+		if (a.dbNumber < b.dbNumber) { return -1; }
+		if (a.dbNumber > b.dbNumber) { return 1; }
+	}
 
 	// But for byte offset we need to start at 0.
 	if (a.offset < b.offset) { return -1; }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodes7",
   "description": "Routine to communicate with Siemens S7 PLCs",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "author": {
 	"name": "Dana Moffit",
 	"email": "nodejsplc@gmail.com"


### PR DESCRIPTION
I was having some problems when reading, where reads of multiple addresses across multiple DBs were returning bad values. After simulating and debugging, i found out nodes7 was making lots of requests out of order, all with size 1. I found then out that the itemListSorter was not considering the DB number (just that it was of the same area code), which then ordered all reads by the byte and bit offset. This was producing a list ordered in this way:

```
DB1020,X0.0
DB1026,X0.0
DB1027,X0.0
DB1021,X0.0
DB1025,X0.0
DB1024,X0.0
DB1027,X0.1
DB1021,X0.1
DB1025,X0.1
DB1020,X0.1
DB1026,X0.1
DB1024,X0.1
DB1021,X0.2
DB1026,X0.2
...
```

This changes itemListSorter, so that items from the same DB are grouped together:

```
DB1020,X0.0
DB1020,X0.1
DB1020,X0.2
DB1020,X0.3
DB1020,X0.4
DB1020,X0.5
...
DB1021,X0.0
DB1021,X0.1
DB1021,X0.2
DB1021,X0.3
DB1021,X0.4
...
```

I also added a debug line that helped me figuring out this problem