### PR TITLE
Handle the case when more than one packet is waiting in the incoming buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version: 0.1.14
+------------
+- Fix bug to handle the case when more than one packet is waiting in the incoming buffer
+
 Version: 0.1.13
 ------------
 - Fix bug when writing a single character

--- a/nodeS7.js
+++ b/nodeS7.js
@@ -1424,7 +1424,7 @@ function checkRFCData(data){
       // Check if its a Fast Acknowledge package from older PLCs or  WinAC or data is too long ...
       // For example: <Buffer 03 00 00 07 02 f0 00> => data.length==7
       ret='fastACK';
-   }else if((LastDataUnit >> 7) == 1 && TPKT_Length === data.length){
+   }else if((LastDataUnit >> 7) == 1 && TPKT_Length <= data.length){
       // Check if its an  FastAcknowledge package + S7Data package
       // <Buffer 03 00 00 1b 02 f0 80 32 03 00 00 00 00 00 08 00 00 00 00 f0 00 00 01 00 01 00 f0> => data.length==7+20=27
       ret=data;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodes7",
   "description": "Routine to communicate with Siemens S7 PLCs",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "author": {
 	"name": "Dana Moffit",
 	"email": "nodejsplc@gmail.com"


### PR DESCRIPTION
Handle the case when more than one packet is waiting in the incoming buffer by allowing packets with a length greater than `TPDU_Length` to be forwarded by `checkRFCData()`