### PR TITLE
Fix #29: Ensure the socket is destroyed on connection cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version: 0.1.15
+------------
+- Ensure the socket is destroyed on connection cleanup
+
 Version: 0.1.14
 ------------
 - Fix bug to handle the case when more than one packet is waiting in the incoming buffer

--- a/nodeS7.js
+++ b/nodeS7.js
@@ -132,8 +132,6 @@ NodeS7.prototype.dropConnection = function(callback) {
 		// but also start a timer to destroy the connection in case we do not receive the close
 		self.dropConnectionTimer = setTimeout(function() {
 			if (self.dropConnectionCallback) {
-				// destroy the socket connection
-				self.isoclient.destroy();
 				// clean up the connection now the socket has closed
 				self.connectionCleanup();
 				// initate the callback
@@ -1394,6 +1392,8 @@ NodeS7.prototype.connectionCleanup = function() {
 	self.isoConnectionState = 0;
 	outputLog('Connection cleanup is happening');
 	if (typeof (self.isoclient) !== "undefined") {
+		// destroy the socket connection
+		self.isoclient.destroy();
 		self.isoclient.removeAllListeners('data');
 		self.isoclient.removeAllListeners('error');
 		self.isoclient.removeAllListeners('connect');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodes7",
   "description": "Routine to communicate with Siemens S7 PLCs",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "author": {
 	"name": "Dana Moffit",
 	"email": "nodejsplc@gmail.com"


### PR DESCRIPTION
Ensure the socket is destroyed on connection cleanup by moving destroy() to connectionCleanup(), fix to #29 and netsmarttech/node-red-contrib-s7#3