### PR TITLE
Implement "localTSAP" and "remoteTSAP" connection options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version: 0.2.0
+------------
+- Implement TSAP mode connection. Allows to directly specify local and remote TSAP values instead of only rack/slot. Useful for connecting with PLCs like Logo.
+
 Version: 0.1.15
 ------------
 - Ensure the socket is destroyed on connection cleanup

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Example usage:
 	};	
 
 	conn.initiateConnection({port: 102, host: '192.168.0.2', rack: 0, slot: 1}, connected); // slot 2 for 300/400, slot 1 for 1200/1500
+	//conn.initiateConnection({port: 102, host: '192.168.0.2', localTSAP: 0x0100, remoteTSAP: 0x0200}, connected); // local and remote TSAP can also be directly specified instead
 
 	function connected(err) {
 		if (typeof(err) !== "undefined") {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodes7",
   "description": "Routine to communicate with Siemens S7 PLCs",
-  "version": "0.1.15",
+  "version": "0.2.0",
   "author": {
 	"name": "Dana Moffit",
 	"email": "nodejsplc@gmail.com"


### PR DESCRIPTION
As discussed in netsmarttech/node-red-contrib-s7#5, here is the implementation of the parameters `localTSAP` and `remoteTSAP` in the connection object, allowing to connect to PLCs like Logo or S7-200.

These parameters are used only when both are given. If not, it falls back to the previous behavior, thus being backwards-compatible with existing software. 

I've also bumped the minor version (to `0.2.0`) because of the new functionality and the fact we're supporting more PLCs, like the semver specs say. But feel free to just increase the patch version :)