### PR TITLE
Change from Buffer.from() to buffer.slice()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version: 0.2.1
+------------
+- Change from `Buffer.from()` to `buffer.slice()`, so we keep compatible with versions of NodeJS older than 6.x
+
 Version: 0.2.0
 ------------
 - Implement TSAP mode connection. Allows to directly specify local and remote TSAP values instead of only rack/slot. Useful for connecting with PLCs like Logo.

--- a/nodeS7.js
+++ b/nodeS7.js
@@ -244,7 +244,7 @@ NodeS7.prototype.onTCPConnect = function() {
 		self.packetTimeout.apply(self, arguments);
 	}, self.globalTimeout, "connect");
 
-	connBuf = Buffer.from(self.connectReq);
+	connBuf = self.connectReq.slice();
 
 	if(self.localTSAP !== null && self.remoteTSAP !== null) {
 		outputLog('Using localTSAP [0x' + self.localTSAP.toString(16) + '] and remoteTSAP [0x' + self.remoteTSAP.toString(16) + ']', 0, self.connectionID);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodes7",
   "description": "Routine to communicate with Siemens S7 PLCs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
 	"name": "Dana Moffit",
 	"email": "nodejsplc@gmail.com"


### PR DESCRIPTION
This has been introduced with the TSAP branch merge. We can use the `slice` method as used before, so we keep compatible with versions of NodeJS older than 6.x

Also reported in netsmarttech/node-red-contrib-s7#6