### PR TITLE
Fix typo

### DIFF
--- a/nodeS7.js
+++ b/nodeS7.js
@@ -1323,7 +1323,7 @@ NodeS7.prototype.readResponse = function(data, foundSeqNum) {
 		// Inform our user that we are done and that the values are ready for pickup.
 
 		outputLog("We are calling back our readDoneCallback.", 1, self.connectionID);
-		if (typeof (self.readDoneCallback === 'function')) {
+		if (typeof (self.readDoneCallback) === 'function') {
 			self.readDoneCallback(anyBadQualities, dataObject);
 		}
 		if (self.resetPending) {


### PR DESCRIPTION
BTW, since `typeof` is not a function and parentheses is optional in specification, why not strip parentheses at all to prevent this kind of typo?