### PR TITLE
Request packet sent is bigger than negotiated PDU size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version: 0.2.4
+------------
+- Fix logging when slicing response packet from PLC
+
 Version: 0.2.3
 ------------
 - Fix support for string arrays

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version: 0.2.5
+------------
+- Fix request packet bigger than PDU size
+
 Version: 0.2.4
 ------------
 - Fix logging when slicing response packet from PLC

--- a/nodeS7.js
+++ b/nodeS7.js
@@ -1105,7 +1105,7 @@ NodeS7.prototype.onResponse = function(theData) {
 		}
 		// The smallest read packet will pass a length check of 25.  For a 1-item write response with no data, length will be 22.
 		if (data.length > data.readInt16BE(2)) {
-			outputLog("An oversize packet was detected.  Excess length is " + data.length - data.readInt16BE(2) + ".  ");
+			outputLog("An oversize packet was detected.  Excess length is " + (data.length - data.readInt16BE(2)) + ".  ");
 			outputLog("We assume this is because two packets were sent at nearly the same time by the PLC.");
 			outputLog("We are slicing the buffer and scheduling the second half for further processing next loop.");
 			setTimeout(function() {

--- a/nodeS7.js
+++ b/nodeS7.js
@@ -875,6 +875,7 @@ NodeS7.prototype.prepareReadPacket = function() {
 
 		// Packet's expected reply length
 		var packetReplyLength = 12 + 2;  //
+		var packetRequestLength = 12; //s7 header and parameter header
 
 		self.readPacketArray.push(new S7Packet());
 		var thisPacketNumber = self.readPacketArray.length - 1;
@@ -885,7 +886,8 @@ NodeS7.prototype.prepareReadPacket = function() {
 
 		for (i = requestNumber; i < requestList.length; i++) {
 			//outputLog("Number is " + (requestList[i].byteLengthWithFill + 4 + packetReplyLength));
-			if (requestList[i].byteLengthWithFill + 4 + packetReplyLength > self.maxPDU) {
+			if (requestList[i].byteLengthWithFill + 4 + packetReplyLength > self.maxPDU || packetRequestLength + 12 > self.maxPDU) {
+				outputLog("Splitting request: " + numItems + " items, requestLength would be " + (packetRequestLength + 12) + ", replyLength would be " + (requestList[i].byteLengthWithFill + 4 + packetReplyLength) + ", PDU is " + self.maxPDU, 1, self.connectionID);
 				if (numItems === 0) {
 					outputLog("breaking when we shouldn't, rlibl " + requestList[i].byteLengthWithFill + " MBR " + maxByteRequest, 0, self.connectionID);
 					throw new Error("Somehow write request didn't split properly - exiting.  Report this as a bug.");
@@ -895,6 +897,7 @@ NodeS7.prototype.prepareReadPacket = function() {
 			requestNumber++;
 			numItems++;
 			packetReplyLength += (requestList[i].byteLengthWithFill + 4);
+			packetRequestLength += 12;
 			//outputLog('I is ' + i + ' Addr Type is ' + requestList[i].addrtype + ' and type is ' + requestList[i].datatype + ' and DBNO is ' + requestList[i].dbNumber + ' and offset is ' + requestList[i].offset + ' bit ' + requestList[i].bitOffset + ' len ' + requestList[i].arrayLength);
 			// skip this for now S7AddrToBuffer(requestList[i]).copy(self.readReq, 19 + numItems * 12);  // i or numItems?
 			self.readPacketArray[thisPacketNumber].itemList.push(requestList[i]);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodes7",
   "description": "Routine to communicate with Siemens S7 PLCs",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": {
 	"name": "Dana Moffit",
 	"email": "nodejsplc@gmail.com"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodes7",
   "description": "Routine to communicate with Siemens S7 PLCs",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {
 	"name": "Dana Moffit",
 	"email": "nodejsplc@gmail.com"


### PR DESCRIPTION
Compute excess length before concatenating with string, preventing to subtract a number from a string, which in turn result to `NaN`, like in issue #38 

Limits the request packet size to the negotiated PDU size, as in issue #40 