### PR TITLE
Bit array length was overwriten

### DIFF
--- a/nodeS7.js
+++ b/nodeS7.js
@@ -2255,8 +2255,7 @@ function stringToS7Addr(addr, useraddr) {
 			} else {
 				theItem.arrayLength = 1;
 			}
-		}
-		if (splitString2.length > 1 && theItem.datatype !== 'X') { // Bit and bit array
+		} else if (splitString2.length > 1 && theItem.datatype !== 'X') { // Bit and bit array
 			theItem.arrayLength = parseInt(splitString2[1].replace(/[A-z]/gi, ''), 10);
 		} else {
 			theItem.arrayLength = 1;


### PR DESCRIPTION
When using a bit array (ex: "Q3.3.4") it is expected to have bitOffset=3 and arrayLength=4, but the next "if" condition with "datatype !== 'X'" was overwriting arrayLength to 1.
The behaviour has been changed to work as expected using "if-else if-else".