### PR TITLE
Tracks all setTimeout calls and handle timers accordingly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "nodes7",
-  "version": "0.2.0",
+  "version": "0.3.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "nodes7",
   "description": "Routine to communicate with Siemens S7 PLCs",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
-	"name": "Dana Moffit",
-	"email": "nodejsplc@gmail.com"
+    "name": "Dana Moffit",
+    "email": "nodejsplc@gmail.com"
   },
   "keywords": [
-	"S7",
-	"Siemens",
-	"PLC",
-	"RFC1006",
-	"iso-on-tcp"
+    "S7",
+    "Siemens",
+    "PLC",
+    "RFC1006",
+    "iso-on-tcp"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
This patch aims to keep track of all `setTimeout()` calls, so we can properly handle these timers and prevent leaking any connection loop after calling `dropConnection()`

This fixes #70, netsmarttech/node-red-contrib-s7#26, and possibly netsmarttech/node-red-contrib-s7#30 and netsmarttech/node-red-contrib-s7#34 too