### PR TITLE
Fixes #80 - prevents write after end

### DIFF
--- a/nodeS7.js
+++ b/nodeS7.js
@@ -310,6 +310,12 @@ NodeS7.prototype.onISOConnectReply = function(data) {
 
 	clearTimeout(self.connectTimeout);
 
+	// ignore if we're not expecting it - prevents write after end exception as of #80
+	if (self.isoConnectionState != 2) { 
+		outputLog('Ignoring ISO connect reply, expecting isoConnectionState of 2, is currently ' + self.isoConnectionState, 0, self.connectionID);
+		return; 
+	}
+
 	// Track the connection state
 	self.isoConnectionState = 3;  // 3 = ISO-ON-TCP connected, Wait for PDU response.
 


### PR DESCRIPTION
Fix proposal for #80 

When the 'end' or 'close' events are emitted, we always call `connectionReset()`, that in turns set `self.isoConnectionState = 0`. Therefore, if we check for the required `self.isoConnectionState` of `2` before proceeding, we should avoid calling write on an already closed stream.

That was the only "unchecked" call of `isoclient.write()`. There may be although other points on the code where the connection gets reset by us and we don't update the `self.isoConnectionState`