### PR TITLE
Implement new DT, DTZ, DTL, DTLZ types

### DIFF
--- a/nodeS7.js
+++ b/nodeS7.js
@@ -1846,7 +1846,7 @@ function readDTL(buffer, offset, isUTC) {
 	let hour = buffer.readUInt8(offset + 5);
 	let min = buffer.readUInt8(offset + 6);
 	let sec = buffer.readUInt8(offset + 7);
-	let ns = buffer.readUInt8(offset + 8);
+	let ns = buffer.readUInt32BE(offset + 8);
 
 	let date;
 	if (isUTC) {


### PR DESCRIPTION
This implements 4 new types: DT, DTZ, DTL, and DTLZ. They all read/write javascript's `Date` format, and handle the conversion for reading/writing internally, replacing the need of user code to handle them

The **DT** type is the well-known DATE_AND_TIME type of S7-300/400 PLCs, a 8-byte-wide field with BCD-encoded parts

The **DTZ** type is the same as the *DT*, but it expects that the timestamp is in UTC in the PLC (usually NOT the case)

The **DTL** type is the one seen on newer S7-1200/1500 PLCs, is 12-byte long and encodes the timestamp differently than the older DATE_AND_TIME

The **DTLZ** type is also the same as the *DTL*, but expecting the timestamp in UTC in the PLC

Note that a javascript's `Date` is _always_ in UTC, and this can cause some confusion to someone not used to that (or even to these ones) :)

Had this code laying around since long time ago, but never had the time to properly implement and test it. This has been also requested on [node-red-contrib-s7#55](https://github.com/netsmarttech/node-red-contrib-s7/issues/55), and the needed changes there are also ready for shipping.

@plcpeople what do you think?
