### PR TITLE
Handle invalid byteLength in processS7Packet

### DIFF
--- a/nodeS7.js
+++ b/nodeS7.js
@@ -1626,6 +1626,11 @@ function processS7Packet(theData, theItem, thePointer, theCID) {
 	if (typeof (theData) === "undefined") {
 		remainingLength = 0;
 		outputLog("Processing an undefined packet, likely due to timeout error", 0, theCID);
+	} else if (isNaN(theItem.byteLength)) {
+		// byteLength Nan should probably never reach this method.
+		// This temporal fix avoids the library crashing
+		outputLog("Processing an undefined packet, perhaps bad input?", 0, theCID);
+		return 0;
 	} else {
 		remainingLength = theData.length - thePointer;  // Say if length is 39 and pointer is 35 we can access 35,36,37,38 = 4 bytes.
 	}


### PR DESCRIPTION
When an item arrives to processS7Packet with a length equal to NaN, probably due to bad input, the library throws a non catchable error.
The check added here prevents this catch from occurring by returning before attempting to allocate a Buffer of length NaN